### PR TITLE
Add background color support and deduplicate format logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,138 +1,29 @@
+import { copyFormat, applyFormat } from './format.js';
+
 chrome.runtime.onInstalled.addListener(() => {
     chrome.contextMenus.create({
       id: "copy-format",
       title: "Copy Format",
       contexts: ["selection"],
     });
-  
+
     chrome.contextMenus.create({
       id: "apply-format",
       title: "Apply Format",
       contexts: ["selection"],
     });
   });
-  
-  chrome.contextMenus.onClicked.addListener((info, tab) => {
-    if (info.menuItemId === "copy-format") {
-      chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        function: copyFormat
-      });
-    } else if (info.menuItemId === "apply-format") {
-      chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        function: applyFormat
-      });
-    }
-  });
-  
-  function copyFormat() {
-    const selection = window.getSelection();
-    if (selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0);
-      const selectedElement = range.startContainer.parentElement;
-  
-      const computedStyle = window.getComputedStyle(selectedElement);
-      const format = {
-        fontFamily: computedStyle.fontFamily,
-        fontSize: computedStyle.fontSize,
-        color: computedStyle.color,
-        fontWeight: computedStyle.fontWeight,
-        fontStyle: computedStyle.fontStyle,
-        textDecoration: computedStyle.textDecoration
-      };
-  
-      sessionStorage.setItem("copiedFormat", JSON.stringify(format));
-    } else {
-      alert("No text selected!");
-    }
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === "copy-format") {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      function: copyFormat
+    });
+  } else if (info.menuItemId === "apply-format") {
+    chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      function: applyFormat
+    });
   }
-  
-  function applyFormat() {
-    const format = JSON.parse(sessionStorage.getItem("copiedFormat"));
-    if (!format) {
-      alert("No format copied!");
-      return;
-    }
-  
-    const selection = window.getSelection();
-    if (selection.rangeCount > 0) {
-      const range = selection.getRangeAt(0);
-  
-      if (range.startContainer === range.endContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
-        const textNode = range.startContainer;
-        const parentElement = textNode.parentElement;
-  
-        const text = textNode.nodeValue;
-        const beforeText = text.substring(0, range.startOffset);
-        const selectedText = text.substring(range.startOffset, range.endOffset);
-        const afterText = text.substring(range.endOffset);
-  
-        if (beforeText) {
-          parentElement.insertBefore(document.createTextNode(beforeText), textNode);
-        }
-  
-        if (selectedText) {
-          const span = document.createElement("span");
-          span.textContent = selectedText;
-          for (const [key, value] of Object.entries(format)) {
-            span.style[key] = value;
-          }
-          parentElement.insertBefore(span, textNode);
-        }
-  
-        if (afterText) {
-          parentElement.insertBefore(document.createTextNode(afterText), textNode);
-        }
-  
-        parentElement.removeChild(textNode);
-      } else {
-        const walker = document.createTreeWalker(
-          range.commonAncestorContainer,
-          NodeFilter.SHOW_TEXT,
-          {
-            acceptNode: (node) =>
-              range.intersectsNode(node) && node.nodeValue.trim() !== "",
-          }
-        );
-  
-        const textNodes = [];
-        while (walker.nextNode()) {
-          textNodes.push(walker.currentNode);
-        }
-  
-        textNodes.forEach((textNode) => {
-          const parentElement = textNode.parentElement;
-  
-          const text = textNode.nodeValue;
-          const startOffset = textNode === range.startContainer ? range.startOffset : 0;
-          const endOffset = textNode === range.endContainer ? range.endOffset : text.length;
-  
-          const beforeText = text.substring(0, startOffset);
-          const selectedText = text.substring(startOffset, endOffset);
-          const afterText = text.substring(endOffset);
-  
-          if (beforeText) {
-            parentElement.insertBefore(document.createTextNode(beforeText), textNode);
-          }
-  
-          if (selectedText) {
-            const span = document.createElement("span");
-            span.textContent = selectedText;
-            for (const [key, value] of Object.entries(format)) {
-              span.style[key] = value;
-            }
-            parentElement.insertBefore(span, textNode);
-          }
-  
-          if (afterText) {
-            parentElement.insertBefore(document.createTextNode(afterText), textNode);
-          }
-  
-          parentElement.removeChild(textNode);
-        });
-      }
-    } else {
-      alert("No text selected!");
-    }
-  }
+});

--- a/format.js
+++ b/format.js
@@ -1,0 +1,118 @@
+export function copyFormat(showAlert = false) {
+  const selection = window.getSelection();
+  if (selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    const selectedElement = range.startContainer.parentElement;
+
+    const computedStyle = window.getComputedStyle(selectedElement);
+    const format = {
+      fontFamily: computedStyle.fontFamily,
+      fontSize: computedStyle.fontSize,
+      color: computedStyle.color,
+      fontWeight: computedStyle.fontWeight,
+      fontStyle: computedStyle.fontStyle,
+      textDecoration: computedStyle.textDecoration,
+      backgroundColor: computedStyle.backgroundColor
+    };
+
+    sessionStorage.setItem('copiedFormat', JSON.stringify(format));
+    if (showAlert) {
+      alert('Formatting copied!');
+    }
+  } else {
+    alert('No text selected!');
+  }
+}
+
+export function applyFormat(showAlert = false) {
+  const format = JSON.parse(sessionStorage.getItem('copiedFormat'));
+  if (!format) {
+    alert('No format copied!');
+    return;
+  }
+
+  const selection = window.getSelection();
+  if (selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+
+    if (range.startContainer === range.endContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
+      const textNode = range.startContainer;
+      const parentElement = textNode.parentElement;
+
+      const text = textNode.nodeValue;
+      const beforeText = text.substring(0, range.startOffset);
+      const selectedText = text.substring(range.startOffset, range.endOffset);
+      const afterText = text.substring(range.endOffset);
+
+      if (beforeText) {
+        parentElement.insertBefore(document.createTextNode(beforeText), textNode);
+      }
+
+      if (selectedText) {
+        const span = document.createElement('span');
+        span.textContent = selectedText;
+        for (const [key, value] of Object.entries(format)) {
+          span.style[key] = value;
+        }
+        parentElement.insertBefore(span, textNode);
+      }
+
+      if (afterText) {
+        parentElement.insertBefore(document.createTextNode(afterText), textNode);
+      }
+
+      parentElement.removeChild(textNode);
+    } else {
+      const walker = document.createTreeWalker(
+        range.commonAncestorContainer,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: (node) =>
+            range.intersectsNode(node) && node.nodeValue.trim() !== ''
+        }
+      );
+
+      const textNodes = [];
+      while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+      }
+
+      textNodes.forEach((textNode) => {
+        const parentElement = textNode.parentElement;
+
+        const text = textNode.nodeValue;
+        const startOffset = textNode === range.startContainer ? range.startOffset : 0;
+        const endOffset = textNode === range.endContainer ? range.endOffset : text.length;
+
+        const beforeText = text.substring(0, startOffset);
+        const selectedText = text.substring(startOffset, endOffset);
+        const afterText = text.substring(endOffset);
+
+        if (beforeText) {
+          parentElement.insertBefore(document.createTextNode(beforeText), textNode);
+        }
+
+        if (selectedText) {
+          const span = document.createElement('span');
+          span.textContent = selectedText;
+          for (const [key, value] of Object.entries(format)) {
+            span.style[key] = value;
+          }
+          parentElement.insertBefore(span, textNode);
+        }
+
+        if (afterText) {
+          parentElement.insertBefore(document.createTextNode(afterText), textNode);
+        }
+
+        parentElement.removeChild(textNode);
+      });
+    }
+
+    if (showAlert) {
+      alert('Formatting applied to selected text!');
+    }
+  } else {
+    alert('No text selected!');
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
     "default_title": "Gmail Format Painter"
   },
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -16,6 +16,6 @@
   <footer>
     <p>A free tool from <a href="https://www.linkedin.com/in/adenning2/" target="_blank">Adam Denning</a></p>
   </footer>
-  <script src="popup.js"></script>
+  <script type="module" src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,8 +1,11 @@
+import { copyFormat, applyFormat } from './format.js';
+
 document.getElementById('copy-format').addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.scripting.executeScript({
       target: { tabId: tabs[0].id },
-      function: copyFormat
+      function: copyFormat,
+      args: [true]
     });
   });
 });
@@ -11,123 +14,8 @@ document.getElementById('apply-format').addEventListener('click', () => {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.scripting.executeScript({
       target: { tabId: tabs[0].id },
-      function: applyFormat
+      function: applyFormat,
+      args: [true]
     });
   });
 });
-
-function copyFormat() {
-  const selection = window.getSelection();
-  if (selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-    const selectedElement = range.startContainer.parentElement;
-
-    const computedStyle = window.getComputedStyle(selectedElement);
-    const format = {
-      fontFamily: computedStyle.fontFamily,
-      fontSize: computedStyle.fontSize,
-      color: computedStyle.color,
-      fontWeight: computedStyle.fontWeight,
-      fontStyle: computedStyle.fontStyle,
-      textDecoration: computedStyle.textDecoration
-    };
-
-    sessionStorage.setItem('copiedFormat', JSON.stringify(format));
-    alert('Formatting copied!');
-  } else {
-    alert('No text selected!');
-  }
-}
-
-function applyFormat() {
-  const format = JSON.parse(sessionStorage.getItem('copiedFormat'));
-  if (!format) {
-    alert('No format copied!');
-    return;
-  }
-
-  const selection = window.getSelection();
-  if (selection.rangeCount > 0) {
-    const range = selection.getRangeAt(0);
-
-    // Check if the selection is within a single text node
-    if (range.startContainer === range.endContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
-      const textNode = range.startContainer;
-      const parentElement = textNode.parentElement;
-
-      const text = textNode.nodeValue;
-      const beforeText = text.substring(0, range.startOffset);
-      const selectedText = text.substring(range.startOffset, range.endOffset);
-      const afterText = text.substring(range.endOffset);
-
-      if (beforeText) {
-        parentElement.insertBefore(document.createTextNode(beforeText), textNode);
-      }
-
-      if (selectedText) {
-        const span = document.createElement("span");
-        span.textContent = selectedText;
-        for (const [key, value] of Object.entries(format)) {
-          span.style[key] = value;
-        }
-        parentElement.insertBefore(span, textNode);
-      }
-
-      if (afterText) {
-        parentElement.insertBefore(document.createTextNode(afterText), textNode);
-      }
-
-      parentElement.removeChild(textNode);
-    } else {
-      // Multi-line or multi-node selection handling
-      const walker = document.createTreeWalker(
-        range.commonAncestorContainer,
-        NodeFilter.SHOW_TEXT,
-        {
-          acceptNode: (node) =>
-            range.intersectsNode(node) && node.nodeValue.trim() !== "",
-        }
-      );
-
-      const textNodes = [];
-      while (walker.nextNode()) {
-        textNodes.push(walker.currentNode);
-      }
-
-      textNodes.forEach((textNode) => {
-        const parentElement = textNode.parentElement;
-
-        const text = textNode.nodeValue;
-        const startOffset = textNode === range.startContainer ? range.startOffset : 0;
-        const endOffset = textNode === range.endContainer ? range.endOffset : text.length;
-
-        const beforeText = text.substring(0, startOffset);
-        const selectedText = text.substring(startOffset, endOffset);
-        const afterText = text.substring(endOffset);
-
-        if (beforeText) {
-          parentElement.insertBefore(document.createTextNode(beforeText), textNode);
-        }
-
-        if (selectedText) {
-          const span = document.createElement("span");
-          span.textContent = selectedText;
-          for (const [key, value] of Object.entries(format)) {
-            span.style[key] = value;
-          }
-          parentElement.insertBefore(span, textNode);
-        }
-
-        if (afterText) {
-          parentElement.insertBefore(document.createTextNode(afterText), textNode);
-        }
-
-        parentElement.removeChild(textNode);
-      });
-    }
-
-    alert('Formatting applied to selected text!');
-  } else {
-    alert('No text selected!');
-  }
-}


### PR DESCRIPTION
## Summary
- consolidate format copy/apply logic into shared module and include background color
- refactor background service worker and popup to use shared functions
- convert background and popup to ES modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea1eb2ab8832484284d15ffe4a559